### PR TITLE
修复生成的PDF文件页面顺序错乱

### DIFF
--- a/peoples_daily_download.py
+++ b/peoples_daily_download.py
@@ -56,6 +56,7 @@ def download(today,partpath,newspaperpatch):
 def merge(partpath,newspaperpatch):
     print("合并中……")
     filelist=os.listdir(partpath)
+    filelist.sort()
     try:
         pdfFM=PyPDF2.PdfFileMerger(strict=False)
     except:


### PR DESCRIPTION
增加了合并PDF时对文件进行排序，保证头版在首页，页面按照顺序合并